### PR TITLE
fix: 规避 getChild 子日志器触发 AstrBot 日志格式化崩溃

### DIFF
--- a/core/logger.py
+++ b/core/logger.py
@@ -3,12 +3,7 @@
 try:
     from astrbot.api import logger as _astrbot_logger
 
-    get_child = getattr(_astrbot_logger, "getChild", None)
-    logger = (
-        get_child("astrbot_plugin_media_parser")
-        if callable(get_child)
-        else _astrbot_logger
-    )
+    logger = _astrbot_logger
 except ImportError:
     import logging
 


### PR DESCRIPTION
fix #85 